### PR TITLE
Update README.md to include correct link. Original used the same link…

### DIFF
--- a/11-Helm-Dev-BuiltIn-Objects/README.md
+++ b/11-Helm-Dev-BuiltIn-Objects/README.md
@@ -182,6 +182,6 @@ File Glob: map[config-files/myconfig2.toml:[97 112 112 78 97 109 101 58 32 109 1
 
 ## Additional Reference
 - [Helm Built-In Objects](https://helm.sh/docs/chart_template_guide/builtin_objects/)
-- [Helm Chart.yaml Fields](https://helm.sh/docs/chart_template_guide/builtin_objects/)
+- [Helm Chart.yaml Fields](https://helm.sh/docs/topics/charts/#the-chartyaml-file)
 
 


### PR DESCRIPTION


The link to the chart.yaml fields are in the docs here: https://helm.sh/docs/chart_template_guide/builtin_objects/

the original links were duplicated on lines 184-185.