### PR TITLE
any non-empty string is considered "truthy"

### DIFF
--- a/14-Helm-Dev-If-Else-AND-BOOLEAN/helmbasics/templates/deployment.yaml
+++ b/14-Helm-Dev-If-Else-AND-BOOLEAN/helmbasics/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
 spec:
-{{- if and .Values.myapp.retail.enableFeature (eq .Values.myapp.env "prod") }}
+{{- if and (eq .Values.myapp.retail.enableFeature true) (eq .Values.myapp.env "prod") }}
   replicas: 6
 {{- else if eq .Values.myapp.env "prod" }}  
   replicas: 4


### PR DESCRIPTION
`helm template myapp1 . --set myapp.retail.enableFeature=yash` command is also satifiying the first `{{ - if }}` condition to make the replica count to 6 as `.Values.myapp.retail.enableFeature` will evaluate to **_true_** when any non-empty value is passed.